### PR TITLE
stream process

### DIFF
--- a/src/molderl_stream.erl
+++ b/src/molderl_stream.erl
@@ -93,8 +93,7 @@ handle_cast({send, Message, StartTime}, State) ->
         true -> % Nope we can't, send what we have and requeue
             erlang:cancel_timer(?STATE.timer_ref),
             NewState = flush(State),
-            molderl_stream:send(self(), Message, StartTime), % requeue latest msg since it didn't fit
-            {noreply, NewState};
+            handle_cast({send, Message, StartTime}, NewState); % reprocess msg now that we have clean buffer
         false -> % Yes we can - add it to the list of messages
             {noreply, ?STATE{message_length=MessageLength, messages=[Message|?STATE.messages]}}
     end.


### PR DESCRIPTION
when reaching full buffer, flush and process latest message right thenwhen reaching full buffer, flush and process latest message right then instead of requeuing, to ensure order of msgs
