### PR TITLE
added reuseaddr flag to socket creation so that sockets can be reopened quickly if app is bounced

### DIFF
--- a/src/molderl_recovery.erl
+++ b/src/molderl_recovery.erl
@@ -46,7 +46,7 @@ init(Arguments) ->
 
     process_flag(trap_exit, true), % so that terminate/2 gets called when process exits
 
-    {ok, Socket} = gen_udp:open(RecoveryPort, [binary, {active,once}]),
+    {ok, Socket} = gen_udp:open(RecoveryPort, [binary, {active,once}, {reuseaddr, true}]),
 
     case file:open(FileName, [read, append, raw, binary, read_ahead]) of
         {ok, IoDevice} ->


### PR DESCRIPTION
Apparently in unix a socket sits on an address for a bit even after it's closed (see http://stackoverflow.com/a/8154529/1743329). This creates an conflict when an app is bounced, eg:

```
2015-03-10 16:20:09.141 [ERROR] Supervisor {<0.137.0>,molderl_stream_sup} had child #Ref<0.0.0.255> started with molderl_stream:start_link([{supervisorpid,<0.137.0>},{streamname,hkse},{destination,{239,192,44,2}},{destinationport,10202},...]) at <0.10169.1> exit with reason no match of right hand value {error,{{{badmatch,{error,eaddrinuse}},[{molderl_recovery,init,1,[{file,"src/molderl_recovery.erl"},{line,49}]},{gen_server,init_it,6,[{file,"gen_server.erl"},{line,304}]},{proc_lib,init_p_do_apply,3,[{file,"proc_lib.erl"},{line,239}]}]},{child,undefined,#Ref<0.0.26.16796>,{molderl_recovery,start_link,[[{filesize,74256492},{index,[0,42,63,136,158,232,255,330,353,376,451,526,762,785,827,869,892,915,1047,1260,1439,1703,2125,2609,2911,3351,3611,3664,3759,3892,4001,4365,4414,4570,4966,5276,5357,...]},...]]},...}}} in molderl_stream:handle_info/2 line 122 in context child_terminated
```

You can specify the reuseaddr flag to prevent this. We already had this in the unit tests, but not in the main source.