### PR TITLE
fixes that will help with the gaps issue

### DIFF
--- a/test/molderl_integration_tests.erl
+++ b/test/molderl_integration_tests.erl
@@ -89,7 +89,7 @@ loop(State=#state{sent=Sent, inflight=Inflight, max_seq_num_rcvd=MaxSeqNumRcvd},
 
 send(State=#state{stream=Stream, sent=Sent}) ->
     % generate random payload of random size < 10 bytes
-    Msg = crypto:strong_rand_bytes(random:uniform(10)), 
+    Msg = crypto:strong_rand_bytes(random:uniform(10)),
     case molderl:send_message(Stream#stream.pid, Msg) of
         ok ->
             Fmt = "[SUCCESS] Sent packet seq num: ~p, msg: ~p",


### PR DESCRIPTION
* buffer_size was not properly reset to 0 when a flush was triggered by a heartbeat
* now using {async, true} for erlang:cancel_timer/2 to prevent blocking
* moved the setting of a new heartbeat up to reduce the potentially large gap between old heartbeat being cancelled and new heartbeat being set off