### PR TITLE
asynchronous erlang:cancel_timer/2 is only in ERTS 7 (R18)

### DIFF
--- a/src/molderl_stream.erl
+++ b/src/molderl_stream.erl
@@ -163,13 +163,15 @@ terminate(Reason, {Info, _State}) ->
 
 -spec flush(#info{}, #state{}) -> {'ok', #state{}} | {'error', inet:posix()}.
 flush(Info, State=#state{sequence_number=undefined}) ->
-    erlang:cancel_timer(State#state.timer_ref, [{async, true}]),
     % can't send messages out because we don't know our sequence number yet
+    % Asynchronous erlang:cancel_timer/2 is only supported in ERTS 7...
+%    erlang:cancel_timer(State#state.timer_ref, [{async, true}]),
     TRef = erlang:send_after(Info#info.prod_interval, self(), prod),
     {ok, State#state{timer_ref=TRef}};
 
 flush(Info=#info{prod_interval=Interval}, State=#state{packets=Pckts}) ->
-    erlang:cancel_timer(State#state.timer_ref, [{async, true}]),
+    % Asynchronous erlang:cancel_timer/2 is only supported in ERTS 7...
+%    erlang:cancel_timer(State#state.timer_ref, [{async, true}]),
     TRef = erlang:send_after(Interval, self(), prod),
     case flush(Info, State#state.sequence_number, lists:reverse(Pckts)) of
         {ok, SeqNum, UnsentPckts} ->


### PR DESCRIPTION
commenting out for now, as I believe the harm of a packet going out even if there's still space for the MTU is smaller than a function blocking on the critical path